### PR TITLE
fix: migration to androidX

### DIFF
--- a/android/src/main/java/com/foo/flutterstatusbarmanager/FlutterStatusbarManagerPlugin.java
+++ b/android/src/main/java/com/foo/flutterstatusbarmanager/FlutterStatusbarManagerPlugin.java
@@ -9,7 +9,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.WindowInsets;
 import android.view.WindowManager;
-import android.support.v4.view.ViewCompat;
+import androidx.core.view.ViewCompat;
 
 import java.util.Map;
 


### PR DESCRIPTION
I changed `import` line because the latest version of Flutter SDK requires `androidx` libraries. 